### PR TITLE
Fix for repeating item annotation bug

### DIFF
--- a/anno_test.go
+++ b/anno_test.go
@@ -70,22 +70,6 @@ func TestFieldFinder(t *testing.T) {
 	notes, err := fn.Find(s)
 	is.NoErr(err)
 
-	is.Equal(len(notes), 3)
-	is.Equal(notes[0].Val, []byte("field"))
-	is.Equal(notes[0].Start, 2)
-	is.Equal(notes[0].End(), 2+len(notes[0].Val))
-	is.Equal(notes[0].Kind, "thiskind")
-
-	is.Equal(notes[1].Val, []byte("able"))
-	is.Equal(notes[1].Start, 23)
-	is.Equal(notes[1].End(), 23+len(notes[1].Val))
-	is.Equal(notes[1].Kind, "thiskind")
-
-	is.Equal(notes[2].Val, []byte("find"))
-	is.Equal(notes[2].Start, 8)
-	is.Equal(notes[2].End(), 8+len(notes[2].Val))
-	is.Equal(notes[2].Kind, "thiskind")
-
 	// sort the notes
 	sort.Sort(notes)
 

--- a/expander_test.go
+++ b/expander_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/cheekybits/is"
-	"github.com/matryer/anno"
+	"github.com/huumn/anno"
 )
 
 func TestExpander(t *testing.T) {

--- a/finders_test.go
+++ b/finders_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/cheekybits/is"
-	"github.com/matryer/anno"
+	"github.com/huumn/anno"
 )
 
 func TestURL(t *testing.T) {
@@ -59,12 +59,13 @@ func TestMention(t *testing.T) {
 
 func TestHashtag(t *testing.T) {
 	is := is.New(t)
-	src := []byte("I love programming in #golang - it's #lovely.")
+	src := []byte("I love programming in #golang - it's #lovely #lovely.")
 	matches, err := anno.Hashtags(src)
 	is.NoErr(err)
 	is.OK(matches)
-	is.Equal(len(matches), 2)
+	is.Equal(len(matches), 3)
 	sort.Sort(matches)
+
 	is.Equal(matches[0].Val, []byte("#golang"))
 	is.Equal(matches[0].Start, 22)
 	is.Equal(matches[0].End(), 22+len(matches[0].Val))
@@ -73,4 +74,8 @@ func TestHashtag(t *testing.T) {
 	is.Equal(matches[1].Start, 37)
 	is.Equal(matches[1].End(), 37+len(matches[1].Val))
 	is.Equal(matches[1].Kind, "hashtag")
+	is.Equal(matches[2].Val, []byte("#lovely"))
+	is.Equal(matches[2].Start, 45)
+	is.Equal(matches[2].End(), 45+len(matches[2].Val))
+	is.Equal(matches[2].Kind, "hashtag")
 }

--- a/finders_test.go
+++ b/finders_test.go
@@ -1,6 +1,7 @@
 package anno_test
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/cheekybits/is"
@@ -14,6 +15,7 @@ func TestURL(t *testing.T) {
 	is.NoErr(err)
 	is.OK(matches)
 	is.Equal(len(matches), 2)
+	sort.Sort(matches)
 	is.Equal(matches[0].Val, []byte("https://downlist.io/"))
 	is.Equal(matches[0].Start, 14)
 	is.Equal(matches[0].End(), 14+len(matches[0].Val))
@@ -44,6 +46,7 @@ func TestMention(t *testing.T) {
 	is.NoErr(err)
 	is.OK(matches)
 	is.Equal(len(matches), 2)
+	sort.Sort(matches)
 	is.Equal(matches[0].Val, []byte("@matryer"))
 	is.Equal(matches[0].Start, 8)
 	is.Equal(matches[0].End(), 8+len(matches[0].Val))
@@ -61,6 +64,7 @@ func TestHashtag(t *testing.T) {
 	is.NoErr(err)
 	is.OK(matches)
 	is.Equal(len(matches), 2)
+	sort.Sort(matches)
 	is.Equal(matches[0].Val, []byte("#golang"))
 	is.Equal(matches[0].Start, 22)
 	is.Equal(matches[0].End(), 22+len(matches[0].Val))


### PR DESCRIPTION
This fixes issue #1 ... Originally, to find the index of a field (the item to be annotated) in the input string, bytes.Index was used which doesn't allow us to distinguish between multiple occurences of the same string.

I fixed this by copying and customizing bytes.Fields to also return the index of each field. 

This also has the performance advantage of removing that use of bytes.Index, which is O(n) where n is length of the string, and solving the problem in O(1).

Honestly, my solution is a bit of maintenance nightmare if bytes.Fields itself has a bug or something and changes, but I didn't have a bunch of time to work around this limitation in the bytes API in some other way.